### PR TITLE
Adjustments to dependencies version management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 25
+    open-pull-requests-limit: 0
     pull-request-branch-name:
       separator: "-"
     commit-message:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,22 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+val flywayVersion by extra("7.3.1")
+val jacksonVersion by extra("2.12.0")
+val kotlinVersion by extra("1.4.21")
+val kotlinCoroutinesVersion by extra("1.4.2-native-mt")
+val postgresVersion by extra("42.2.18")
+val postgresR2dbcVersion by extra("0.8.6.RELEASE")
+val reactorKotlinVersion by extra("1.1.1")
+val r2dbcPoolVersion by extra("0.8.5.RELEASE")
+val reactorTestVersion by extra("3.4.1")
+val springBootVersion by extra("2.4.0")
+val testContainersVersion by extra("1.15.0")
+
 plugins {
-	id("org.springframework.boot") version "2.4.0"
-	id("io.spring.dependency-management") version "1.0.10.RELEASE"
-	kotlin("jvm") version "1.4.10"
-	kotlin("plugin.spring") version "1.4.10"
+    id("org.springframework.boot") version "2.4.0"
+    id("io.spring.dependency-management") version "1.0.10.RELEASE"
+    kotlin("jvm") version "1.4.21"
+    kotlin("plugin.spring") version "1.4.21"
 }
 
 group = "com.ricardocosta"
@@ -12,45 +24,41 @@ version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_11
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
-
-extra["testcontainersVersion"] = "1.15.0"
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-actuator")
-	implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
-	implementation("org.springframework.boot:spring-boot-starter-validation")
-	implementation("org.springframework.boot:spring-boot-starter-webflux")
-	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-	implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
-	implementation("org.flywaydb:flyway-core")
-	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
-	developmentOnly("org.springframework.boot:spring-boot-devtools")
-	runtimeOnly("io.r2dbc:r2dbc-postgresql")
-	runtimeOnly("org.postgresql:postgresql")
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testImplementation("io.projectreactor:reactor-test")
-	testImplementation("org.testcontainers:junit-jupiter")
-	testImplementation("org.testcontainers:postgresql")
-	testImplementation("org.testcontainers:r2dbc")
-}
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    implementation("io.projectreactor.kotlin:reactor-kotlin-extensions:$reactorKotlinVersion")
+    implementation("org.flywaydb:flyway-core:$flywayVersion")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$kotlinCoroutinesVersion")
+    implementation("org.springframework.boot:spring-boot-starter-actuator:$springBootVersion")
+    implementation("org.springframework.boot:spring-boot-starter-data-r2dbc:$springBootVersion")
+    implementation("org.springframework.boot:spring-boot-starter-validation:$springBootVersion")
+    implementation("org.springframework.boot:spring-boot-starter-webflux:$springBootVersion")
+    implementation(platform("org.testcontainers:testcontainers-bom:$testContainersVersion"))
 
-dependencyManagement {
-	imports {
-		mavenBom("org.testcontainers:testcontainers-bom:${property("testcontainersVersion")}")
-	}
+    developmentOnly("org.springframework.boot:spring-boot-devtools:$springBootVersion")
+
+    runtimeOnly("io.r2dbc:r2dbc-postgresql:$postgresR2dbcVersion")
+    runtimeOnly("org.postgresql:postgresql:$postgresVersion")
+
+    testImplementation("io.projectreactor:reactor-test:$reactorTestVersion")
+    testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
+    testImplementation("org.testcontainers:junit-jupiter:$testContainersVersion")
+    testImplementation("org.testcontainers:postgresql:$testContainersVersion")
+    testImplementation("org.testcontainers:r2dbc:$testContainersVersion")
 }
 
 tasks.withType<KotlinCompile> {
-	kotlinOptions {
-		freeCompilerArgs = listOf("-Xjsr305=strict")
-		jvmTarget = "11"
-	}
+    kotlinOptions {
+        freeCompilerArgs = listOf("-Xjsr305=strict")
+        jvmTarget = "11"
+    }
 }
 
 tasks.withType<Test> {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val flywayVersion by extra("7.3.1")
@@ -14,6 +15,7 @@ val testContainersVersion by extra("1.15.0")
 
 plugins {
     id("org.springframework.boot") version "2.4.0"
+    id("com.github.ben-manes.versions") version "0.36.0"
     id("io.spring.dependency-management") version "1.0.10.RELEASE"
     kotlin("jvm") version "1.4.21"
     kotlin("plugin.spring") version "1.4.21"
@@ -61,4 +63,20 @@ tasks.withType<KotlinCompile> {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+tasks.named("dependencyUpdates", DependencyUpdatesTask::class.java).configure {
+    fun isNonStable(version: String): Boolean {
+        val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.toUpperCase().contains(it) }
+        val regex = "^[0-9,.v-]+(-r)?$".toRegex()
+        val isStable = stableKeyword || regex.matches(version)
+        return isStable.not()
+    }
+
+    rejectVersionIf {
+        isNonStable(candidate.version)
+    }
+
+    checkForGradleUpdate = true
+    gradleReleaseChannel = "current"
 }


### PR DESCRIPTION
- Extract the dependencies versions to variables so that they are explicit and easier to manage.
- Add Gradle Versions Plugin <sup>1</sup> so that we can check for dependencies updates.
- Disable Dependabot as it is not compatible with Gradle build files using KotlinScript.

(1) https://github.com/ben-manes/gradle-versions-plugin