### PR TITLE
Add endpoint configuration

### DIFF
--- a/src/main/kotlin/com/ricardocosta/template/configuration/WebConfig.kt
+++ b/src/main/kotlin/com/ricardocosta/template/configuration/WebConfig.kt
@@ -1,9 +1,12 @@
 package com.ricardocosta.template.configuration
 
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.web.ReactivePageableHandlerMethodArgumentResolver
+import org.springframework.data.web.ReactiveSortHandlerMethodArgumentResolver
 import org.springframework.web.reactive.config.EnableWebFlux
 import org.springframework.web.reactive.config.PathMatchConfigurer
 import org.springframework.web.reactive.config.WebFluxConfigurer
+import org.springframework.web.reactive.result.method.annotation.ArgumentResolverConfigurer
 
 @Configuration
 @EnableWebFlux
@@ -12,5 +15,12 @@ class WebConfig : WebFluxConfigurer {
         configurer
             .setUseCaseSensitiveMatch(true)
             .setUseTrailingSlashMatch(false)
+    }
+
+    override fun configureArgumentResolvers(configurer: ArgumentResolverConfigurer) {
+        configurer.addCustomResolver(
+            ReactiveSortHandlerMethodArgumentResolver(),
+            ReactivePageableHandlerMethodArgumentResolver()
+        )
     }
 }

--- a/src/main/kotlin/com/ricardocosta/template/configuration/WebConfig.kt
+++ b/src/main/kotlin/com/ricardocosta/template/configuration/WebConfig.kt
@@ -1,0 +1,16 @@
+package com.ricardocosta.template.configuration
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.config.EnableWebFlux
+import org.springframework.web.reactive.config.PathMatchConfigurer
+import org.springframework.web.reactive.config.WebFluxConfigurer
+
+@Configuration
+@EnableWebFlux
+class WebConfig : WebFluxConfigurer {
+    override fun configurePathMatching(configurer: PathMatchConfigurer) {
+        configurer
+            .setUseCaseSensitiveMatch(true)
+            .setUseTrailingSlashMatch(false)
+    }
+}


### PR DESCRIPTION
Configure the rules for endpoint matching. In our project, endpoints are case sensitive (`/users` won't match to `/Users`) and do not match if there is a trailing slash (`/users` does not match to `/users/`).

Add the necessary configuration to automatically create instances of `Sort` and `Pageable` based on query parameters.