### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+<a name="0.3.0"></a>
+## 0.3.0 (2021/02/01)
+
+
+## Features
+
+* Add example POST endpoint ([2cb28e9b](https://github.com/ricardocosta/reactive-spring-template/commits/2cb28e9b))
+* Configure OpenAPI ([a573068c](https://github.com/ricardocosta/reactive-spring-template/commits/a573068c))
+* Add Blockhound integration ([661c2519](https://github.com/ricardocosta/reactive-spring-template/commits/661c2519))
+
+## Chore
+
+* Bump gradle-commitlint-plugin to 1.4
+* Reenable dependabot
+* bump io.gitlab.arturbosch.detekt from 1.15.0-RC1 to 1.15.0
+* bump io.spring.dependency-management
+* bump org.springframework.boot from 2.4.0 to 2.4.2
+* bump plugin.spring from 1.4.21 to 1.4.21-2
+* bump jvm from 1.4.21 to 1.4.21-2
+* bump ru.netris.commitlint from 1.4 to 1.4.1
 <a name="0.2.0"></a>
 ## 0.2.0 (2020/12/20)
 


### PR DESCRIPTION
## 0.3.0 (2021/02/01)


## Features

* Add example POST endpoint ([2cb28e9b](https://github.com/ricardocosta/reactive-spring-template/commits/2cb28e9b))
* Configure OpenAPI ([a573068c](https://github.com/ricardocosta/reactive-spring-template/commits/a573068c))
* Add Blockhound integration ([661c2519](https://github.com/ricardocosta/reactive-spring-template/commits/661c2519))

## Chore

* Bump gradle-commitlint-plugin to 1.4
* Reenable dependabot
* bump io.gitlab.arturbosch.detekt from 1.15.0-RC1 to 1.15.0
* bump io.spring.dependency-management
* bump org.springframework.boot from 2.4.0 to 2.4.2
* bump plugin.spring from 1.4.21 to 1.4.21-2
* bump jvm from 1.4.21 to 1.4.21-2
* bump ru.netris.commitlint from 1.4 to 1.4.1